### PR TITLE
add max speed in m/s, fix k/hr to km/hr

### DIFF
--- a/docs/specifications.rst
+++ b/docs/specifications.rst
@@ -37,7 +37,7 @@ Specifications Overview
   * - Motor
     - 2 x 350w hub motors
   * - Maximum Speed
-    - 3.6k/hr
+    - 1.0m/s (3.6km/hr)
   * - Turning Radius
     - 0°
   * - Payload Capacity


### PR DESCRIPTION
This updates the spec to match the PDF version in having m/s (which is the proper SI unit for speed)